### PR TITLE
to_json passes an argument around when it to_jsons its children.

### DIFF
--- a/lib/lightspeed/collection.rb
+++ b/lib/lightspeed/collection.rb
@@ -128,8 +128,8 @@ module Lightspeed
       { resource_name => all_loaded.map(&:to_h) }
     end
 
-    def to_json
-      to_h.to_json
+    def to_json(*args)
+      to_h.to_json(*args)
     end
 
     def page(n, per_page: PER_PAGE, params: {})

--- a/lib/lightspeed/resource.rb
+++ b/lib/lightspeed/resource.rb
@@ -112,8 +112,8 @@ module Lightspeed
       "#<#{self.class.name} API#{base_path}>"
     end
 
-    def to_json
-      to_h.to_json
+    def to_json(*args)
+      to_h.to_json(*args)
     end
 
     def to_h


### PR DESCRIPTION
should fix #8.
