### PR TITLE
Enable OAuth tokens to be refreshed, version 0.3.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,8 +9,10 @@ Not all endpoints are implemented yet, but you can help by submitting pull reque
 First, intialize a new client:
 
 ```ruby
-client = Lightspeed::Client.new(oauth_token: "YOUR_ACCESS_TOKEN_HERE")
+client = Lightspeed::Client.new(oauth_token_holder: yourOAuthAwareObjectHere)
 ```
+
+`yourOAuthAwareObjectHere` must be an object that responds to `oauth_token` and `refresh_oauth_token`. `oauth_token` must return an access token, and `refresh_oauth_token` must handle the refreshing of expired access tokens, so that a subsequent call to `oauth_token` will return a new, unexpired access token.
 
 Next, make a request for your accounts:
 

--- a/bin/console
+++ b/bin/console
@@ -5,13 +5,31 @@ require 'dotenv'
 require 'lightspeed_pos'
 Lightspeed::Request.verbose = true
 
+class TokenHolder
+  def initialize(token: nil, refresh_token: nil)
+    @token = token
+    @refresh_token = refresh_token
+  end
+
+  def oauth_token
+    @token
+  end
+
+  def refresh_oauth_token
+    raise "Token expired, refresh not yet implemented"
+  end
+end
+
 # require "pry"
 # Pry.start
 Dotenv.load
 def client
   token = ENV['LIGHTSPEED_OAUTH_TOKEN']
+  refresh_token = ENV['LIGHTSPEED_OAUTH_REFRESH_TOKEN']
   raise 'set LIGHTSPEED_OAUTH_TOKEN as an envorinment variable to use this' unless token
-  @client ||= Lightspeed::Client.new(oauth_token: token)
+  raise 'set LIGHTSPEED_OAUTH_REFRESH_TOKEN as an envorinment variable to use this' unless refresh_token
+  token_holder = Tokenholder.new(token: token, refresh_token: refresh_token)
+  @client ||= Lightspeed::Client.new(oauth_token_holder: token_holder)
 end
 
 def account

--- a/lib/lightspeed/client.rb
+++ b/lib/lightspeed/client.rb
@@ -6,11 +6,13 @@ require_relative 'request_throttler'
 
 module Lightspeed
   class Client
-    attr_accessor :oauth_token, :throttler
+    attr_accessor :throttler
 
-    def initialize(oauth_token: nil)
-      @oauth_token = oauth_token
+    def initialize(oauth_token_holder: nil, oauth_token: nil)
+      @oauth_token_holder = oauth_token_holder
       @throttler = Lightspeed::RequestThrottler.new
+
+      raise "Passing an oauth token is no longer supported. Pass a token holder instead." if oauth_token
     end
 
     # Returns a list of accounts that you have access to.
@@ -34,6 +36,14 @@ module Lightspeed
       perform_request(args.merge(method: :delete))
     end
 
+    def oauth_token
+      @oauth_token_holder.oauth_token
+    end
+
+    def refresh_oauth_token
+      @oauth_token_holder.refresh_oauth_token
+    end
+
     private
 
     def perform_request(**args)
@@ -43,6 +53,5 @@ module Lightspeed
     def request **args
       Lightspeed::Request.new(self, **args)
     end
-
   end
 end

--- a/lib/lightspeed/version.rb
+++ b/lib/lightspeed/version.rb
@@ -1,3 +1,3 @@
 module Lightspeed
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/fixtures/vcr_cassettes/accounts_oauth_with_refresh.yml
+++ b/spec/fixtures/vcr_cassettes/accounts_oauth_with_refresh.yml
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Authorization:
-      - Bearer test
+      - Bearer test_refreshed
   response:
     status:
       code: 200
@@ -59,7 +59,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Authorization:
-      - Bearer test
+      - Bearer test_refreshed
   response:
     status:
       code: 200
@@ -90,4 +90,53 @@ http_interactions:
         Kraft Sandbox","link":{"@attributes":{"href":"\/API\/Account\/120645"}}}}'
     http_version: 
   recorded_at: Sat, 13 Feb 2016 00:46:37 GMT
+- request:
+    method: get
+    uri: https://api.merchantos.com/API/Account.json?limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bearer test
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 04 Apr 2017 00:49:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '143'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc1d4c524ae206ff9d35312ee959ac03c1491266968; expires=Wed, 04-Apr-18
+        00:49:28 GMT; path=/; domain=.merchantos.com; HttpOnly
+      Www-Authenticate:
+      - Basic realm="MerchantOS API"
+      X-Ls-Master-Account:
+      - 'false'
+      X-Ls-Master-Catalog:
+      - 'false'
+      X-Ls-Master-System:
+      - 'false'
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 34a0449b1f011d80-MEL
+    body:
+      encoding: UTF-8
+      string: '{"httpCode":"401","httpMessage":"Unauthorized","message":"Invalid username\/password
+        or API key.","errorClass":"BadAuthenticationRequestError"}'
+    http_version: 
+  recorded_at: Tue, 04 Apr 2017 00:49:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lightspeed/client_spec.rb
+++ b/spec/lightspeed/client_spec.rb
@@ -1,28 +1,58 @@
 require 'spec_helper'
 
+class ExampleTokenHolder
+  def initialize(token: nil, refresh_token: nil)
+    @token = token
+    @refresh_token = refresh_token
+  end
+
+  def oauth_token
+    @token
+  end
+
+  def refresh_oauth_token
+    @token = @token + "_refreshed"
+  end
+end
+
 describe Lightspeed::Client do
-  it "can set an oauth token" do
+  it "can set an oauth token holder and fetch an access token from it" do
     key = 'test'
-    client = Lightspeed::Client.new(oauth_token: key)
+    token_holder = ExampleTokenHolder.new(token: key)
+    client = Lightspeed::Client.new(oauth_token_holder: token_holder)
     expect(client.oauth_token).to eq(key)
   end
 
   it "sets the oauth token up for a request" do
     key = 'test'
-    client = Lightspeed::Client.new(oauth_token: key)
+    token_holder = ExampleTokenHolder.new(token: key)
+    client = Lightspeed::Client.new(oauth_token_holder: token_holder)
     request = client.send(:request, method: :get, path: '/')
-    expect(request.raw_request["Authorization"]).to eq("OAuth test")
+    expect(request.raw_request["Authorization"]).to eq("Bearer test")
   end
 
   it "can fetch accounts using an oauth token" do
-    VCR.use_cassette("accounts_oauth") do
+    VCR.use_cassette("accounts_oauth", match_requests_on: [:anonymised_path, :method, :body, :headers]) do
       oauth_token = ENV.fetch('LIGHTSPEED_OAUTH_TOKEN', 'test')
-      client = Lightspeed::Client.new(oauth_token: oauth_token)
+      token_holder = ExampleTokenHolder.new(token: oauth_token)
+      client = Lightspeed::Client.new(oauth_token_holder: token_holder)
       accounts = client.accounts
       expect(accounts).to be_a(Lightspeed::Accounts)
       expect(accounts.length).to eq(1)
-      expect(accounts.first.id).to eq(120645)
+      expect(accounts.first.id).to eq(120_645)
     end
   end
 
+  it "will refresh an oauth token when it has expired" do
+    VCR.use_cassette("accounts_oauth_with_refresh", match_requests_on: [:anonymised_path, :method, :body, :headers]) do
+      token_holder = ExampleTokenHolder.new(token: 'test', refresh_token: 'unused')
+      client = Lightspeed::Client.new(oauth_token_holder: token_holder)
+      expect(client.oauth_token).to eq 'test'
+      accounts = client.accounts
+      expect(accounts).to be_a(Lightspeed::Accounts)
+      expect(accounts.length).to eq(1)
+      expect(accounts.first.id).to eq(120_645)
+      expect(client.oauth_token).to eq 'test_refreshed'
+    end
+  end
 end

--- a/spec/lightspeed/request_throttler_spec.rb
+++ b/spec/lightspeed/request_throttler_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
-describe Lightspeed::RequestThrottler do
+class ExampleTokenHolder
+  def initialize(token: nil, refresh_token: nil)
+    @token = token
+    @refresh_token = refresh_token
+  end
 
-  let(:client) { Lightspeed::Client.new(oauth_token: ENV.fetch('LIGHTSPEED_OAUTH_TOKEN', 'test')) }
+  def oauth_token
+    @token
+  end
+end
+
+describe Lightspeed::RequestThrottler do
+  let(:client) { Lightspeed::Client.new(oauth_token_holder: ExampleTokenHolder.new(token: ENV.fetch('LIGHTSPEED_OAUTH_TOKEN', 'test'))) }
 
   it "can extract limits from API responses" do
     VCR.use_cassette("request_throttler/bucket_limits") do
@@ -13,6 +23,4 @@ describe Lightspeed::RequestThrottler do
   end
 
   pending "can slow down to avoid hitting the limit"
-
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each do |f|
 end
 
 Lightspeed::TEST_OAUTH_TOKEN = ENV['LIGHTSPEED_OAUTH_TOKEN']
+Lightspeed::TEST_OAUTH_REFRESH_TOKEN = ENV['LIGHTSPEED_OAUTH_REFRESH_TOKEN']
 Lightspeed::TEST_ACCOUNT_ID = ENV['LIGHTSPEED_ACCOUNT_ID'].to_i
 
 VCR.configure do |config|
@@ -24,6 +25,9 @@ VCR.configure do |config|
 
   unless Lightspeed::TEST_OAUTH_TOKEN.blank?
     config.filter_sensitive_data('OAuth Token') { Lightspeed::TEST_OAUTH_TOKEN }
+  end
+  unless Lightspeed::TEST_OAUTH_REFRESH_TOKEN.blank?
+    config.filter_sensitive_data('OAuth Refresh Token') { Lightspeed::TEST_OAUTH_REFRESH_TOKEN }
   end
   unless Lightspeed::TEST_ACCOUNT_ID.blank?
     config.filter_sensitive_data('/API/Account/-') { "/API/Account/#{Lightspeed::TEST_ACCOUNT_ID}" }

--- a/spec/support/client_and_account.rb
+++ b/spec/support/client_and_account.rb
@@ -1,11 +1,20 @@
 module ClientAndAccount
+  class ExampleTokenHolder
+    def initialize(token: nil, refresh_token: nil)
+      @token = token
+      @refresh_token = refresh_token
+    end
+
+    def oauth_token
+      @token
+    end
+  end
+
   def setup_client_and_account
     let(:client) do
-      if !Lightspeed::TEST_OAUTH_TOKEN.blank?
-        Lightspeed::Client.new(oauth_token: Lightspeed::TEST_OAUTH_TOKEN)
-      else
-        Lightspeed::Client.new
-      end
+      token = Lightspeed::TEST_OAUTH_TOKEN || nil
+      token_holder = ExampleTokenHolder.new(token: token)
+      Lightspeed::Client.new(oauth_token_holder: token_holder)
     end
 
     let(:accounts) do


### PR DESCRIPTION
Make sure that OAuth tokens can be refreshed when they expire, but
without taking on the responsibility for the OAuth interaction. Leave
that responsibility with the user of this gem.

Note that the creation of Lightspeed::Client has been changed, which
is intentional.