### PR TITLE
retry throttled requests after handling unauthorized errors

### DIFF
--- a/lib/lightspeed/request.rb
+++ b/lib/lightspeed/request.rb
@@ -57,9 +57,11 @@ module Lightspeed
     rescue Lightspeed::Error::Throttled
       retry_throttled_request
     rescue Lightspeed::Error::Unauthorized
+      raise e if @attempted_oauth_token_refresh
       @client.refresh_oauth_token
       set_authorization_header
-      perform_raw
+      @attempted_oauth_token_refresh = true
+      perform
     end
 
     private

--- a/lib/lightspeed/request.rb
+++ b/lib/lightspeed/request.rb
@@ -56,7 +56,7 @@ module Lightspeed
       perform_raw
     rescue Lightspeed::Error::Throttled
       retry_throttled_request
-    rescue Lightspeed::Error::Unauthorized
+    rescue Lightspeed::Error::Unauthorized => e
       raise e if @attempted_oauth_token_refresh
       @client.refresh_oauth_token
       set_authorization_header


### PR DESCRIPTION
https://rollbar.com/bikeexchange/lightspeed-bridge/items/328/?item_page=0&item_count=100&#traceback

Issue: request `perform` method does not rescue any potential throttled errors after handling unauthorised errors, causing `Lightspeed::Error::Throttled` errors to be raised for some accounts without retrying requests.