### PR TITLE
Trigger rate limit backoff if we're close to the bucket max, not over it

### DIFF
--- a/lib/lightspeed/request_throttler.rb
+++ b/lib/lightspeed/request_throttler.rb
@@ -10,7 +10,10 @@ module Lightspeed
 
     def perform_request request
       u = units request
-      sleep(u / @units_per_second) if @bucket_level + u > @bucket_max
+      # Because of concurrent processes, we always try to stay under the bucket max by a margin
+      if @bucket_level + u > @bucket_max - 20
+        sleep(u / @units_per_second)
+      end
       response = request.perform
       extract_rate_limits request
       response


### PR DESCRIPTION
We're having ongoing throttling issues with lightspeed that I'm trying to fix. At the heart of the issue is the fact that our request throttling code doesn't handle concurrency well. Previously, if we'd used 88 out of 90 requests for the current 'bucket' of time, each process would still make the next request anyway (they remember the request count from their last request). Here we change the check to try to keep the request count _under_ the bucket limit, not exactly at the bucket limit. I'd like to revisit this later, but I think it's worth testing it for now.