### PR TITLE
Add fix for assigning Item attributes when nil

### DIFF
--- a/lib/lightspeed/resource.rb
+++ b/lib/lightspeed/resource.rb
@@ -17,7 +17,7 @@ module Lightspeed
     end
 
     def attributes=(attributes)
-      @attributes = attributes
+      @attributes = attributes ||= {}
       attributes.each do |key, value|
         send(:"#{key}=", value) if self.respond_to?(:"#{key}=")
       end

--- a/spec/lightspeed/item_spec.rb
+++ b/spec/lightspeed/item_spec.rb
@@ -41,4 +41,9 @@ describe Lightspeed::Item do
   it "can show a JSON representation of an item" do
     expect(subject.to_json).to eq("{\"itemID\":2}")
   end
+
+  # regression test - https://rollbar.com/bikeexchange/lightspeed-bridge/items/483/
+  it "does not try to set an attribute with a key that is nil" do
+    subject.attributes = nil
+  end
 end


### PR DESCRIPTION
https://rollbar.com/bikeexchange/lightspeed-bridge/items/483/

Attributes should never be nil, regardless of the source.