### PR TITLE
Add publishToEcom field to Item

### DIFF
--- a/lib/lightspeed/item.rb
+++ b/lib/lightspeed/item.rb
@@ -50,6 +50,7 @@ module Lightspeed
       ItemShelfLocations: :hash,
       ItemVendorNums: :hash,
       CustomFieldValues: :hash,
+      publishToEcom: :boolean,
       Prices: :hash,
       Tags: :hash
     )


### PR DESCRIPTION
Add publishToEcom field to Item object.

When retail with eCom Item should have field publishToEcom to check if this item is publish to eCom or not:

https://retail-support.lightspeedhq.com/hc/en-us/articles/235177128-Publishing-items-in-eCom