### PR TITLE
use double splat for keyword argument expansion

### DIFF
--- a/lib/lightspeed/accounts.rb
+++ b/lib/lightspeed/accounts.rb
@@ -13,7 +13,7 @@ module Lightspeed
       first_loaded || first
     end
 
-    def page(n, *args)
+    def page(n, **args)
       # turns out lightspeed doesn't respect pagination for accounts.
       # so page(1) is identical to page(0).
       # they should be different, thus.

--- a/spec/lightspeed/accounts_spec.rb
+++ b/spec/lightspeed/accounts_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Lightspeed::Accounts do
+  describe "#page" do
+    it "relays keyword arguments" do
+      VCR.use_cassette("accounts_oauth", match_requests_on: [:anonymised_path, :method, :body, :headers]) do
+        key = 'test'
+        token_holder = ExampleTokenHolder.new(token: key)
+        client = Lightspeed::Client.new(oauth_token_holder: token_holder)
+        expect { client.accounts.all }.not_to raise_error ArgumentError
+      end
+    end
+  end
+end

--- a/spec/lightspeed/accounts_spec.rb
+++ b/spec/lightspeed/accounts_spec.rb
@@ -9,7 +9,7 @@ describe Lightspeed::Accounts do
         key = 'test'
         token_holder = ExampleTokenHolder.new(token: key)
         client = Lightspeed::Client.new(oauth_token_holder: token_holder)
-        expect { client.accounts.all }.not_to raise_error ArgumentError
+        expect { client.accounts.all }.not_to raise_error
       end
     end
   end

--- a/spec/lightspeed/client_spec.rb
+++ b/spec/lightspeed/client_spec.rb
@@ -2,21 +2,6 @@
 
 require 'spec_helper'
 
-class ExampleTokenHolder
-  def initialize(token: nil, refresh_token: nil)
-    @token = token
-    @refresh_token = refresh_token
-  end
-
-  def oauth_token
-    @token
-  end
-
-  def refresh_oauth_token
-    @token = @token + "_refreshed"
-  end
-end
-
 describe Lightspeed::Client do
   it "can set an oauth token holder and fetch an access token from it" do
     key = 'test'

--- a/spec/support/example_token_holder.rb
+++ b/spec/support/example_token_holder.rb
@@ -1,0 +1,15 @@
+class ExampleTokenHolder
+  def initialize(token: nil, refresh_token: nil)
+    @token = token
+    @refresh_token = refresh_token
+  end
+
+  def oauth_token
+    @token
+  end
+
+  def refresh_oauth_token
+    @token = @token + "_refreshed"
+  end
+end
+


### PR DESCRIPTION
A fix for a keyword argument error in Ruby 3.  Spec included.