### PR TITLE
chore: update rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
+  SuggestExtensions:
+    rubocop-rake: false
+    rubocop-rspec: false
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: always_ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.6
   - 2.7
   - 3.0
+before_install:
+  - gem install bundler --version $(ruby -e "puts File.read(File.join(Dir.pwd, 'Gemfile.lock')).scan /BUNDLED WITH\n\s*([\d.]+)$/")
 script:
   - 'bundle exec rubocop'
   - 'bundle exec rspec spec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 script:
   - 'bundle exec rubocop'
   - 'bundle exec rspec spec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,93 @@
+PATH
+  remote: .
+  specs:
+    lightspeed_pos (0.5.0)
+      activesupport
+      yajl-ruby
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.8)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    hashdiff (1.0.1)
+    i18n (1.8.8)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.14.3)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.6)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.9.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
+    vcr (6.0.0)
+    webmock (3.11.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    yajl-ruby (1.4.1)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bundler
+  dotenv
+  lightspeed_pos!
+  pry
+  rake
+  rspec
+  rubocop
+  vcr
+  webmock
+
+BUNDLED WITH
+   2.2.7

--- a/lib/lightspeed/collection.rb
+++ b/lib/lightspeed/collection.rb
@@ -176,7 +176,7 @@ module Lightspeed
       params = { load_relations: load_relations_default }
         .merge(context_params)
         .merge(params)
-        .reject { |_, v| v.nil? }
+        .compact
       client.get(
         path: collection_path,
         params: params

--- a/lib/lightspeed/error.rb
+++ b/lib/lightspeed/error.rb
@@ -3,10 +3,15 @@
 module Lightspeed
   class Error < Exception
     class BadRequest < Lightspeed::Error; end # 400
+
     class Unauthorized < Lightspeed::Error; end # 401
+
     class NotAuthorized < Lightspeed::Error; end # 403
+
     class NotFound < Lightspeed::Error; end # 404
+
     class InternalServerError < Lightspeed::Error; end # 500
+
     class Throttled < Lightspeed::Error; end # 503
   end
 end

--- a/lib/lightspeed/request.rb
+++ b/lib/lightspeed/request.rb
@@ -108,7 +108,7 @@ module Lightspeed
 
     def uri
       uri = self.class.base_path + @path
-      uri += "?" + URI.encode_www_form(@params) if @params && @method == :get
+      uri += "?#{URI.encode_www_form(@params)}" if @params && @method == :get
       uri
     end
 

--- a/lib/lightspeed/resource.rb
+++ b/lib/lightspeed/resource.rb
@@ -8,7 +8,7 @@ require_relative 'collection'
 
 module Lightspeed
   class ID < Integer; end
-  class Link; end
+  class Link; end # rubocop:disable Lint/EmptyClass
   class Resource
     attr_accessor :id, :attributes, :client, :context, :account
 
@@ -48,8 +48,7 @@ module Lightspeed
       if value.is_a?(String)
         case kind
         when :string then value
-        when :integer then value.to_i
-        when :id then value.to_i
+        when :id, :integer then value.to_i
         when :datetime then DateTime.parse(value)
         when :boolean then value == 'true'
         when :decimal then BigDecimal(value)

--- a/lightspeed_pos.gemspec
+++ b/lightspeed_pos.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 2.5'
+
   spec.add_dependency "activesupport"
   spec.add_dependency "yajl-ruby"
 

--- a/spec/lightspeed/client_spec.rb
+++ b/spec/lightspeed/client_spec.rb
@@ -13,7 +13,7 @@ class ExampleTokenHolder
   end
 
   def refresh_oauth_token
-    @token = @token + "_refreshed"
+    @token = "#{@token}_refreshed"
   end
 end
 


### PR DESCRIPTION
HEAD was failing on travis, to fix that:

- update rubocop and then change code to pass the latest rubocop
- include Gemfile.lock in repo to make sure we keep the same versions for tests
- add ruby 3.0 to travis tests