### PR TITLE
Migrate pipeline definition to repository

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - command: "script/buildkite"
+    label: "Tests"
+    agents:
+      queue: default

--- a/script/buildkite
+++ b/script/buildkite
@@ -17,7 +17,6 @@ REAL_CORES=`cat /proc/cpuinfo | grep "core id" | sort | uniq | wc -l`
 
 # Pull image if we don't have a locally cached version
 if ! docker images "$IMAGE" | grep --quiet "$IMAGE"; then
-  eval $(aws --region "$REGION" ecr get-login)
   docker pull "$IMAGE"
 fi
 


### PR DESCRIPTION
Previously the pipeline was defined in buildkite and the actual build was in a batch file. To enable us to migrate to a multi-step build using docker-compose described in pipeline.yml we need to migrate the existing build definition into the repo before we upgrade it.

## Checklist

- [x] Cross-browser testing
- [x] Deployed to an environment
- [x] PR has appropriate labels added (needs-testing, etc.)
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.

**See:** https://app.tettra.co/teams/marketplacer/pages/system-acquisition-and-development-policy
**See:** https://app.tettra.co/teams/marketplacer/pages/threat-modelling
